### PR TITLE
updated readme and added chrome driver manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ tags
 virtualenv
 
 docs-build/
+.idea/

--- a/README.rst
+++ b/README.rst
@@ -56,16 +56,18 @@ daily historical price data for the past twenty years:
 .. code-block:: python
 
   from tda import auth, client
+  from webdriver_manager.chrome import ChromeDriverManager
   import json
-
-  token_path = '/path/to/token.pickle'
+  # path to saved stored token after successful authentication
+  token_path = './token.pickle'
+  # consumer key for application found on TD Ameritrade developer website
   api_key = 'YOUR_API_KEY@AMER.OAUTHAP'
-  redirect_uri = 'https://your.redirecturi.com'
+  redirect_uri = 'https://localhost'
   try:
       c = auth.client_from_token_file(token_path, api_key)
   except FileNotFoundError:
       from selenium import webdriver
-      with webdriver.Chrome() as driver:
+      with webdriver.Chrome(ChromeDriverManager().install()) as driver:
           c = auth.client_from_login_flow(
               driver, api_key, redirect_uri, token_path)
 

--- a/README.rst
+++ b/README.rst
@@ -58,7 +58,7 @@ daily historical price data for the past twenty years:
   from tda import auth, client
   from webdriver_manager.chrome import ChromeDriverManager
   import json
-  # path to saved stored token after successful authentication
+  # path to save stored token after successful authentication
   token_path = './token.pickle'
   # consumer key for application found on TD Ameritrade developer website
   api_key = 'YOUR_API_KEY@AMER.OAUTHAP'

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ selenium
 sphinx_rtd_theme
 twine
 websockets
+webdriver-manager


### PR DESCRIPTION
* Added `.idea/` to `.gitignore` for pycharm users
* Added documentation about `api_key` to clarify it is the `Consumer Key` found on developer website
* Change `redirect_uri` to `https://localhost`. The variable name specifies that it is the redirection uri, so having a url that does that same is redundant. By changing the default redirection URI you satisfy those who have it set as `https://localhost` whereas the former satisfies no one.
* Added `webdriver-manager` in the example so it can run seamlessly. Chrome updates every 24 hours, and so the burden of maintaining chrome driver should be ignored. First the person would have to go to settings in Chrome to identify their Chrome version, then go to the chrome driver website to download it, then they would have to identify where the default path it should be installed for Windows or Mac OS, and then repeatedly have to do that on updates. Seams like too much of a hassle.