### PR TITLE
Fix `enable_bug_report_logging`

### DIFF
--- a/tda/debug.py
+++ b/tda/debug.py
@@ -129,7 +129,7 @@ def _enable_bug_report_logging(output=sys.stderr, loggers=None):
     if loggers is None:
         loggers = (
             tda.auth.get_logger(),
-            tda.client.get_logger(),
+            tda.client.base.get_logger(),
             tda.streaming.get_logger(),
             get_logger())
 

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -148,3 +148,12 @@ class RegisterRedactionsTest(unittest.TestCase):
         resp = MR({'success': 1}, 200)
         tda.debug.register_redactions_from_response(resp)
         register_redactions.assert_not_called()
+
+  class EnableDebugLoggingTest(unittest.TestCase):
+
+    @patch('logging.Logger.addHandler')
+    def test_enable_doesnt_throw_exceptions(self, _):
+      try:
+        tda.debug.enable_bug_report_logging()
+      except AttributeError:
+        self.fail("debug.enable_bug_report_logging() raised AttributeError unexpectedly")

--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -149,7 +149,7 @@ class RegisterRedactionsTest(unittest.TestCase):
         tda.debug.register_redactions_from_response(resp)
         register_redactions.assert_not_called()
 
-  class EnableDebugLoggingTest(unittest.TestCase):
+class EnableDebugLoggingTest(unittest.TestCase):
 
     @patch('logging.Logger.addHandler')
     def test_enable_doesnt_throw_exceptions(self, _):


### PR DESCRIPTION
The method `_enable_bug_report_logging` was throwing exceptions. When called without any loggers specified, it requests loggers from all the modules. For the `client` module this was done with `self.client.get_logger()` which no longer works, because that method is now nested inside a `base` module, so it should read: `self.client.get_logger()`.

I also added a unit test to catch this behavior.