### PR TITLE
Fix failing build workflow due to Github's warning

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python.version }}
-      uses: actions/setup-python@v1.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python.version }}
 
@@ -57,7 +57,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python.version }}
-      uses: actions/setup-python@v1.1.1
+      uses: actions/setup-python@v2
       with:
         python-version: 3.8
     - name: Install dependencies


### PR DESCRIPTION
The workflow actions using `actions/setup-python@v1.1.1` are now failing the build, due to a change on GitHub's side. Replaced with current recommendation.

See, e.g.
- https://stackoverflow.com/questions/64288543/how-and-why-upgrade-a-github-workflow-to-use-environment-files
- https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/