### PR TITLE
Fixes automatic token refresh bug

### DIFF
--- a/tda/auth.py
+++ b/tda/auth.py
@@ -263,9 +263,8 @@ def client_from_access_functions(api_key, token_read_func,
     api_key = __normalize_api_key(api_key)
 
     session_kwargs = {
-            'token': token,
-            'auto_refresh_url': 'https://api.tdameritrade.com/v1/oauth2/token',
-            'auto_refresh_kwargs': {'client_id': api_key},
+        'token': token,
+        'token_endpoint': 'https://api.tdameritrade.com/v1/oauth2/token',
     }
 
     if token_write_func is not None:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -46,8 +46,7 @@ class ClientFromTokenFileTest(unittest.TestCase):
         session.assert_called_once_with(
             API_KEY,
             token=self.token,
-            auto_refresh_url=_,
-            auto_refresh_kwargs=_,
+            token_endpoint=_,
             update_token=_)
 
     @no_duplicates
@@ -64,8 +63,7 @@ class ClientFromTokenFileTest(unittest.TestCase):
         session.assert_called_once_with(
             API_KEY,
             token=self.token,
-            auto_refresh_url=_,
-            auto_refresh_kwargs=_,
+            token_endpoint=_,
             update_token=_)
 
     @no_duplicates
@@ -100,8 +98,7 @@ class ClientFromTokenFileTest(unittest.TestCase):
         session.assert_called_once_with(
             'API_KEY@AMER.OAUTHAP',
             token=self.token,
-            auto_refresh_url=_,
-            auto_refresh_kwargs=_,
+            token_endpoint=_,
             update_token=_)
 
 
@@ -128,8 +125,7 @@ class ClientFromAccessFunctionsTest(unittest.TestCase):
         session.assert_called_once_with(
             'API_KEY@AMER.OAUTHAP',
             token=token,
-            auto_refresh_url=_,
-            auto_refresh_kwargs=_,
+            token_endpoint=_,
             update_token=_)
         token_read_func.assert_called_once()
 
@@ -159,8 +155,7 @@ class ClientFromAccessFunctionsTest(unittest.TestCase):
         session.assert_called_once_with(
             'API_KEY@AMER.OAUTHAP',
             token=token,
-            auto_refresh_url=_,
-            auto_refresh_kwargs=_)
+            token_endpoint=_)
         token_read_func.assert_called_once()
 
 


### PR DESCRIPTION
... by passing the parameter (`token_endpoint`) that `authlib` expects which differed from what the prior OAuth library wanted. The code hadn't been updated to reflect the requirements of the `authlib` client when the repo was switched to it.

The second `client_id` in the `auto_refresh_kwargs` also wasn't needed.

Fixed corresponding unit tests. Verified the functionality in a script running against live TDAmeritrade servers.

Resolves #128 .