### PR TITLE
Fix strike range enum to match tdameritrade docs

### DIFF
--- a/tda/client/base.py
+++ b/tda/client/base.py
@@ -541,12 +541,12 @@ class BaseClient(EnumEnforcer):
             ROLL = 'ROLL'
 
         class StrikeRange(Enum):
-            IN_THE_MONEY = 'IN_THE_MONEY'
-            NEAR_THE_MONEY = 'NEAR_THE_MONEY'
-            OUT_OF_THE_MONEY = 'OUT_OF_THE_MONEY'
-            STRIKES_ABOVE_MARKET = 'STRIKES_ABOVE_MARKET'
-            STRIKES_BELOW_MARKET = 'STRIKES_BELOW_MARKET'
-            STRIKES_NEAR_MARKET = 'STRIKES_NEAR_MARKET'
+            IN_THE_MONEY = 'ITM'
+            NEAR_THE_MONEY = 'NTM'
+            OUT_OF_THE_MONEY = 'OTM'
+            STRIKES_ABOVE_MARKET = 'SAK'
+            STRIKES_BELOW_MARKET = 'SBK'
+            STRIKES_NEAR_MARKET = 'SNK'
             ALL = 'ALL'
 
         class Type(Enum):


### PR DESCRIPTION
https://developer.tdameritrade.com/option-chains/apis/get/marketdata/chains

```
Returns options for the given range. Possible values are:

ITM: In-the-money
NTM: Near-the-money
OTM: Out-of-the-money
SAK: Strikes Above Market
SBK: Strikes Below Market
SNK: Strikes Near Market
ALL: All Strikes

Default is ALL.
```