### PR TITLE
Only use Pickle if explicitly requested

### DIFF
--- a/tda/auth.py
+++ b/tda/auth.py
@@ -33,14 +33,11 @@ def __token_loader(token_path):
 
         with open(token_path, 'rb') as f:
             token_data = f.read()
-            try:
-                return json.loads(token_data.decode())
-            except ValueError:
-                get_logger().warning(
-                    "Unable to load JSON token from file {}, falling back to pickle"\
-                    .format(token_path)
-                )
+            if token_path.endswith(".pickle") or "TDA_LOAD_WITH_PICKLE" in os.environ:
                 return pickle.loads(token_data)
+            else:
+                return json.loads(token_data.decode())
+
     return load_token
 
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -57,7 +57,7 @@ class ClientFromTokenFileTest(unittest.TestCase):
     @patch('tda.auth.OAuth2Client')
     def test_pickle_loads_with_environ_variable(self, session, client):
         import os
-        os.environ["TDA_LOAD_WITH_PICKLE"] = ""
+        os.environ["TDA_USE_PICKLE"] = ""
         try:
             self.write_token()
 
@@ -74,7 +74,7 @@ class ClientFromTokenFileTest(unittest.TestCase):
         except Exception as e:
             raise e
         finally:
-            del os.environ["TDA_LOAD_WITH_PICKLE"]
+            del os.environ["TDA_USE_PICKLE"]
 
     @no_duplicates
     @patch('tda.auth.Client')


### PR DESCRIPTION
Only use Pickle if explicitly requested
    
This change makes it so Pickle must be explicitly requested by either supplying
a filename ending in ".pickle", or by passing an environment variable TDA_USE_PICKLE.
    
I believe this is a worthwhile security hardening measure for two reasons:
    
- The previous code used pickle when it encountered a failure. As pickle is tantamount
   to arbitrary code execution, calling it on a failure path seems unwise.
    
- Because tda-api's focus is on automated trading, not only is it a security critical
   application, but it is reasonable to believe that it will execute adjacent to scripts
   that automatically download files (eg to download data for indicators). If a script were
   to overwrite the token with a malicious pickle, it could lead to unpleasant financial
   consequences (eg buying a toxic asset on margin, or transferring funds).
