### PR TITLE
fix bug in Get Orders By Path where no orders are retrieved with default inputs of fromEnteredTime & toEnteredTime

### DIFF
--- a/tda/client/base.py
+++ b/tda/client/base.py
@@ -155,18 +155,12 @@ class BaseClient(EnumEnforcer):
         if status is not None and statuses is not None:
             raise ValueError('at most one of status or statuses may be set')
 
-        if from_entered_datetime is None:
-            from_entered_datetime = datetime.datetime(
-                year=1900, month=1, day=1)
-        if to_entered_datetime is None:
-            to_entered_datetime = datetime.datetime.utcnow()
+        params = {}
+        if from_entered_datetime is not None:
+            params['fromEnteredTime'] = from_entered_datetime
 
-        params = {
-            'fromEnteredTime': self._format_datetime(
-                'from_entered_datetime', from_entered_datetime),
-            'toEnteredTime': self._format_datetime(
-                'to_entered_datetime', to_entered_datetime),
-        }
+        if to_entered_datetime is not None:
+            params['toEnteredTime'] = to_entered_datetime
 
         if max_results:
             params['maxResults'] = max_results


### PR DESCRIPTION
td-api doesnt return any order if the from data is in year 1900.
This fix will not pass the fromEnteredTime and toEnteredTime params if the function doesnt override the from/toEnteredTime None Defaults.