### PR TITLE
updating timesale example for account_id to int

### DIFF
--- a/examples/streaming/timesales.py
+++ b/examples/streaming/timesales.py
@@ -5,7 +5,7 @@ import asyncio
 import pprint
 
 API_KEY = "XXXXXX"
-ACCOUNT_ID = "XXXXXX"
+ACCOUNT_ID = 000000
 
 
 class MyStreamConsumer:


### PR DESCRIPTION
instead of updating the streaming client to be able to take both int/string and breaking test, easy fix is to update the example