### PR TITLE
Update __init__.py

### DIFF
--- a/tda/orders/__init__.py
+++ b/tda/orders/__init__.py
@@ -3,3 +3,4 @@ from enum import Enum
 from . import common
 from . import equities
 from . import generic
+from . import options


### PR DESCRIPTION
Fix missing options import

Unable to import options as expected using tda.order.options as reflected in the [documentation](https://tda-api.readthedocs.io/en/stable/order-templates.html#tda.orders.options)

```
import tda
tda.orders.options 
# This is undefined
```