### PR TITLE
Optionally Allow Direct Passing of Values with EnumEnforcer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,7 @@ tags
 virtualenv
 
 docs-build/
+
+# Common IDE/editor data directories
+.vscode/
+.idea/

--- a/tda/client/base.py
+++ b/tda/client/base.py
@@ -32,10 +32,10 @@ class BaseClient(EnumEnforcer):
     checking status codes. For methods which support responses, they can be
     found in the response object's ``json()`` method.'''
 
-    def __init__(self, api_key, session, *, enforce_enums=True):
+    def __init__(self, api_key, session, *, enforce_enums=True, allow_values=False):
         '''Create a new client with the given API key and session. Set
         `enforce_enums=False` to disable strict input type checking.'''
-        super().__init__(enforce_enums)
+        super().__init__(enforce_enums, allow_values=allow_values)
 
         self.api_key = api_key
         self.session = session

--- a/tda/utils.py
+++ b/tda/utils.py
@@ -8,46 +8,132 @@ import re
 
 
 class EnumEnforcer:
-    def __init__(self, enforce_enums):
+    '''Ensures values passed to the enum conversion methods are members of the 
+    correct enum type with ``enforce_enums=True``. With ``allow_values=True``, 
+    allows directly passing member values instead, but rejects values which are not 
+    defined in the relevant enumeration. With `enforce_enums=False`, any value is 
+    allowed (and `allow_values` is ignored).
+
+    :param enforce_enums: True to enable parameter validation, False otherwise.
+    :param allow_values: True to allow direct passing of enumerated values, False to
+        only allow members of the appropriate enum. Ignored with ``enforce_enums=False``.
+    '''
+    def __init__(self, enforce_enums, allow_values=False):
         self.enforce_enums = enforce_enums
+        self.allow_values = allow_values
 
-    def type_error(self, value, required_enum_type):
-        raise ValueError(
-            ('expected type "{}", got type "{}" (initialize with ' +
-             'enforce_enums=True to disable this checking)').format(
-                required_enum_type.__name__,
-                type(value).__name__))
+    def _raise_unrecognized_value(self, value, enum_type):
+        error_str = ('Value "{actual}" is not is not enumerated in {enum}. Check the '
+                     'official TD Ameritrade API documentation to see what values are '
+                     'allowed. If the value you need is missing from {enum}, you can '
+                     'disable parameter validation by initializing {subclass} with '
+                     'enforce_enums=False. However, if an allowed value is truly not '
+                     'enumerated in {enum}, please submit an issue to {repo_url} '
+                     'including the name of the enum, a link to the relevant '
+                     'official documentation, and the missing value.')
+        raise UnrecognizedValueException(
+            error_str.format(
+                actual=type(value).__name__,
+                enum=enum_type.__name__,
+                subclass=self.__class__.__name__,
+                repo_url="https://github.com/alexgolec/tda-api",
+            )
+        )
 
-    def convert_enum(self, value, required_enum_type):
+    def _raise_enum_required(self, value, required_enum_type):
+        error_str = ('Expected type {expected}, got type "{actual}". Initialize '
+                     '{subclass} with allow_values=True to allow direct usage of '
+                     'enumerated values, or use enforce_enums=False to disable '
+                     'validation altogether. Check the official TD Ameritrade API '
+                     'documentation to see what values are allowed. If an allowed '
+                     'value is truly not enumerated in {expected}, please submit an '
+                     'issue to {repo_url} including the name of the enum, a link to '
+                     'the relevant official documentation, and the missing value.')
+        raise EnumRequiredException(
+            error_str.format(
+                expected=required_enum_type.__name__, 
+                actual=type(value).__name__,
+                subclass=self.__class__.__name__,
+                repo_url="https://github.com/alexgolec/tda-api"
+            )
+        )
+
+    def convert_enum(self, value, required_enum_type, allowed_values=None):
+        '''Validate the given ``value`` using ``required_enum_type``.
+
+        With ``self.enforce_enums=True``, check that the given ``value`` is a member of 
+        the required type, and return its value if so. 
+        
+        With ``self.allow_values=True``, also allows ``value`` to be an enumerated value 
+        in the required enum type, returning ``value`` back unchanged if so.
+        
+        With ``self.enforce_enums=False``, if ``value`` is a member of the expected enum,
+        returns ``value.value``, otherwise, returns ``value`` unchanged.
+
+        :param value: The object in question.
+        :param required_enum_type: The expected enum type.
+        :param allowed_values: The set of values which are allowed with 
+            ``self.allow_values=True``, or None to use the set of all values enumerated
+            in ``required_enum_type``. Providing this set is useful to avoid repeated
+            recomputation of allowed values. Ignored if value validation is turned off.
+        :raise EnumRequiredException: if ``value`` is not a member of the required enum
+            type, ``self.enforce_enums=True``, and ``self.allow_values=False``.
+        :raise UnrecognizedValueException: if ``value`` is not a member of the required 
+            enum type nor one of its enumerated values, and ``self.enforce_enums=True``,
+            and ``self.allow_values=True``.
+        :return: either ``value`` or ``value.value`` as appropriate.
+        '''
         if value is None:
             return None
-
         if isinstance(value, required_enum_type):
             return value.value
-        elif self.enforce_enums:
-            self.type_error(value, required_enum_type)
-        else:
-            return value
+        if self.enforce_enums:
+            if self.allow_values:
+                if allowed_values is None:
+                    allowed_values = set(member.value for member in required_enum_type)
+                if value in allowed_values:
+                    return value
+                self._raise_unrecognized_value(value, required_enum_type)
+            self._raise_enum_required(value, required_enum_type)
+        return value
 
     def convert_enum_iterable(self, iterable, required_enum_type):
+        '''Return the ``iterable`` of parameters with all elements converted as needed
+           by :meth:`EnumEnforcer.convert_enum_iterable`. 
+           
+        If ``iterable`` is a member of the appropriate enum (not an iterable), returns a
+        list containg ``iterable`` as its only element. This does not work when passing
+        values directly--even a single value must be contained in an iterable.
+        '''
         if iterable is None:
             return None
-
         if isinstance(iterable, required_enum_type):
             return [iterable.value]
-
-        values = []
-        for value in iterable:
-            if isinstance(value, required_enum_type):
-                values.append(value.value)
-            elif self.enforce_enums:
-                self.type_error(value, required_enum_type)
-            else:
-                values.append(value)
-        return values
+        allowed_values = set(member.value for member in required_enum_type)
+        return [
+            self.convert_enum(value, required_enum_type, allowed_values=allowed_values) 
+            for value in iterable
+        ]
 
     def set_enforce_enums(self, enforce_enums):
         self.enforce_enums = enforce_enums
+
+class UnrecognizedValueException(ValueError):
+    '''
+    Raised by :meth:`EnumEnforcer.convert_enum` when a parameter is passed which is
+    not enumerated in the required enum type, and value validation is enabled.
+
+    Inherits from ``ValueError``.
+    '''
+
+
+class EnumRequiredException(TypeError, ValueError):
+    '''
+    Raised by :meth:`EnumEnforcer.convert_enum` when a parameter is passed which is
+    not a member of the required enum type and enum-only enforcement is enabled.
+
+    Inherits from both ``TypeError`` and ``ValueError`` for backwards compatibility.
+    '''
 
 
 class UnsuccessfulOrderException(ValueError):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,14 @@
+from enum import Enum
+
 from unittest.mock import MagicMock
-from tda.utils import AccountIdMismatchException, Utils
-from tda.utils import UnsuccessfulOrderException
+from tda.utils import (
+    Utils,
+    EnumEnforcer,
+    AccountIdMismatchException, 
+    UnsuccessfulOrderException,
+    UnrecognizedValueException,
+    EnumRequiredException,
+)
 from . import test_utils
 from .utils import no_duplicates, MockResponse
 
@@ -90,3 +98,216 @@ class UtilsTest(unittest.TestCase):
             'https://api.tdameritrade.com/v1/accounts/{}/orders/{}'.format(
                 self.account_id, order_id)})
         self.assertEqual(order_id, self.utils.extract_order_id(response))
+
+
+class FooEnum(Enum):
+    FOO = "something"
+    BAR = "somethingelse"
+    BAZ = "anotherthing"
+
+
+class AlphabetEnum(Enum):
+    A = 1
+    B = 2
+    C = 3
+    D = 4
+    E = 5
+
+
+class EnumEnforcerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.enforcers = {
+            'strict':  EnumEnforcer(True),
+            'value': EnumEnforcer(True, True),
+            'permissive': EnumEnforcer(False),
+            'alt_permissive': EnumEnforcer(False, True),
+        }
+
+    def assert_enforcers_return_or_raise(self, method, args, kwargs, return_mapping):
+        '''Assert that, when the EnumEnforcer ``method`` is called with the given 
+        ``args`` and ``kwargs``, each enforcer named in ``return_mapping`` returns 
+        the value or raises the exception type in ``return_mapping[name]``. For the
+        sake of simplicity, iterables must be lists for this method to check them.'''
+        for name, ret_val in return_mapping.items():
+            identifier = (
+                "Test of EnumEnforcer '{enforcer}': {method}(*{args}, **{kwargs}) "
+                "Expected: {ret_val}"
+            ).format(
+                enforcer=name, 
+                method=method.__name__, 
+                args=args, 
+                kwargs=kwargs, 
+                ret_val=ret_val,
+            )
+            with self.subTest(description=identifier):
+                if isinstance(ret_val, type) and issubclass(ret_val, Exception):
+                    with self.assertRaises(ret_val):
+                        method(self.enforcers[name], *args, **kwargs)
+                elif isinstance(ret_val, list):
+                    self.assertListEqual(
+                        method(self.enforcers[name], *args, **kwargs), 
+                        ret_val
+                    )
+                else:
+                    self.assertEqual(
+                        method(self.enforcers[name], *args, **kwargs),
+                        ret_val
+                    )
+
+
+    def test_convert_enum_valid_foo_member(self):
+        self.assert_enforcers_return_or_raise(
+            method=EnumEnforcer.convert_enum,
+            args=(FooEnum.FOO, FooEnum),
+            kwargs={},
+            return_mapping={
+                'strict': FooEnum.FOO.value,
+                'value': FooEnum.FOO.value,
+                'permissive': FooEnum.FOO.value,
+                'alt_permissive': FooEnum.FOO.value,
+            }
+        )
+
+    def test_convert_enum_valid_alph_member(self):
+        self.assert_enforcers_return_or_raise(
+            method=EnumEnforcer.convert_enum,
+            args=(AlphabetEnum.C, AlphabetEnum),
+            kwargs={},
+            return_mapping={
+                'strict': 3,
+                'value': 3,
+                'permissive': 3,
+                'alt_permissive': 3,
+            }
+        )
+
+    def test_convert_enum_wrong_type(self):
+        self.assert_enforcers_return_or_raise(
+            method=EnumEnforcer.convert_enum,
+            args=(AlphabetEnum.C, FooEnum),
+            kwargs={},
+            return_mapping={
+                'strict': EnumRequiredException,
+                'value': UnrecognizedValueException,
+                'permissive': AlphabetEnum.C,
+                'alt_permissive': AlphabetEnum.C,
+            }
+        )
+
+    def test_convert_enum_with_valid_value(self):
+        self.assert_enforcers_return_or_raise(
+            method=EnumEnforcer.convert_enum,
+            args=('somethingelse', FooEnum),
+            kwargs={},
+            return_mapping={
+                'strict': EnumRequiredException,
+                'value': 'somethingelse',
+                'permissive': 'somethingelse',
+                'alt_permissive': 'somethingelse',
+            }
+        )
+    
+    def test_convert_enum_with_invalid_value(self):
+        self.assert_enforcers_return_or_raise(
+            method=EnumEnforcer.convert_enum,
+            args=('I am not valid.', FooEnum),
+            kwargs={},
+            return_mapping={
+                'strict': EnumRequiredException,
+                'value': UnrecognizedValueException,
+                'permissive': 'I am not valid.',
+                'alt_permissive': 'I am not valid.',
+            }
+        )
+
+    def test_convert_enum_uses_allowed_values(self):
+        self.assert_enforcers_return_or_raise(
+            method=EnumEnforcer.convert_enum,
+            args=(2, AlphabetEnum),
+            kwargs={'allowed_values': set([5])},
+            return_mapping={
+                'strict': EnumRequiredException,
+                'value': UnrecognizedValueException,
+                'permissive': 2,
+                'alt_permissive': 2,
+            }
+        )
+
+    def test_convert_enum_iterable_with_valid_members(self):
+        self.assert_enforcers_return_or_raise(
+            method=EnumEnforcer.convert_enum_iterable,
+            args=([FooEnum.BAZ, FooEnum.FOO, FooEnum.BAR], FooEnum),
+            kwargs={},
+            return_mapping={
+                'strict': ['anotherthing', 'something', 'somethingelse'],
+                'value': ['anotherthing', 'something', 'somethingelse'],
+                'permissive': ['anotherthing', 'something', 'somethingelse'],
+                'alt_permissive': ['anotherthing', 'something', 'somethingelse'],
+            }
+        )
+    
+    def test_convert_enum_iterable_with_wrong_member(self):
+        self.assert_enforcers_return_or_raise(
+            method=EnumEnforcer.convert_enum_iterable,
+            args=([FooEnum.BAZ, AlphabetEnum.A, FooEnum.BAR], FooEnum),
+            kwargs={},
+            return_mapping={
+                'strict': EnumRequiredException,
+                'value': UnrecognizedValueException,
+                'permissive': ['anotherthing', AlphabetEnum.A, 'somethingelse'],
+                'alt_permissive': ['anotherthing', AlphabetEnum.A, 'somethingelse'],
+            }
+        )
+
+    def test_convert_enum_iterable_with_valid_values(self):
+        self.assert_enforcers_return_or_raise(
+            method=EnumEnforcer.convert_enum_iterable,
+            args=([3, 2], AlphabetEnum),
+            kwargs={},
+            return_mapping={
+                'strict': EnumRequiredException,
+                'value': [3, 2],
+                'permissive': [3, 2],
+                'alt_permissive': [3, 2],
+            }
+        )
+
+    def test_convert_enum_iterable_with_invalid_values(self):
+        self.assert_enforcers_return_or_raise(
+            method=EnumEnforcer.convert_enum_iterable,
+            args=([71, 2], AlphabetEnum),
+            kwargs={},
+            return_mapping={
+                'strict': EnumRequiredException,
+                'value': UnrecognizedValueException,
+                'permissive': [71, 2],
+                'alt_permissive': [71, 2],
+            }
+        )
+
+    def test_convert_enum_iterable_with_lone_member(self):
+        self.assert_enforcers_return_or_raise(
+            method=EnumEnforcer.convert_enum_iterable,
+            args=(AlphabetEnum.A, AlphabetEnum),
+            kwargs={},
+            return_mapping={
+                'strict': [1],
+                'value': [1],
+                'permissive': [1],
+                'alt_permissive': [1],
+            }
+        )
+
+    def test_convert_enum_iterable_with_lone_value(self):
+        self.assert_enforcers_return_or_raise(
+            method=EnumEnforcer.convert_enum_iterable,
+            args=(2, AlphabetEnum),
+            kwargs={},
+            return_mapping={
+                'strict': TypeError,
+                'value': TypeError,
+                'permissive': TypeError,
+                'alt_permissive': TypeError,
+            }
+        )


### PR DESCRIPTION
I decided to make a change to `EnumEnforcer` in the fork of this repository that I have been using, and figured I'd clean it up, add tests, and run it by you guys. Please consider this PR as a suggestion--I will not be offended if you'd rather not implement this feature, especially given that I did not consult with anyone about this change. Feel free to "take it or leave it".

I fully agree with the rationale behind storing the allowed API request parameters in `Enum`s and having automatic usage enforcement. However, when using a `Client` in an in interactive console, I found it a bit annoying to have to keep switching between the official API docs and the `tda-api` docs to locate the correct `Enum`s to use for every request parameter. The imports are also very verbose, and generally not very conducive to interactive usage.

As a result, I propose the following compromise: optionally allow direct passing of values using a new keyword for `EnumEnforcer` (and `BaseClient`) called `allow_values` which, when set to `True`, causes `EnumEnforcer` to allow the direct passage of enumerated values, as long as they are given as definitions in the relevant `Enum` subclass. It essentially turns `EnumEnforcer` into a spell-checker. I believe I have managed to implement this feature without breaking backwards compatibility, with the possible exception of `EnumEnforcer.type_error` (I'm not sure if this method was considered to be public facing--it was not documented) which, interestingly, had the effect of raising a `ValueError`.

I also noticed that the `EnumEnforcer` class did  not have unit tests, so I went ahead and wrote them (accounting for this new keyword argument as well as original use cases). I added some new exceptions called `UnrecognizedValueException` (a `ValueError` subclass) and `EnumRequiredException` (which inherits from both `TypeError` and `ValueError` for backwards compatibility). `EnumRequiredException` is raised by `EnumEnforcer` when an invalid value is passed and `enforce_enums` is `True` but `allow_values` is `False`. `UnrecognizedValueException` is raised when an invalid value is passed while both are set to `True`.

There was also an issue with the `ValueError` `EnumEnforcer` raised--the description said to set `enforce_enums` to `True` to *disable* the parameter checking. I assume this was unintentional. I went ahead and changed the error messages to explain the two keywords and also link to this repository in case a valid value is missing from an `Enum`.

`EnumEnforcer.convert_enum_iterable` was also refactored to use repeated calls to `convert_enum` instead of implementing its own logic. I noticed that `convert_enum_iterable` was written such that it was acceptable to pass a single enum member, which would be converted to a list of one element. I kept this functionality for backwards compatibility, but only for when an enum member is passed--not when a value is passed. This is because an instance of `str` is both a valid value for some enums but also an iterable, so it makes more sense to just force the user to use a sequence of one element instead in this case.

Please let me know if this is of interest to the maintainers/community of this repo. Cheers!