### PR TITLE
get_orders_by_path uses datetimes while expecting dates

### DIFF
--- a/tda/client/base.py
+++ b/tda/client/base.py
@@ -157,16 +157,16 @@ class BaseClient(EnumEnforcer):
             raise ValueError('at most one of status or statuses may be set')
 
         if from_entered_datetime is None:
-            from_entered_datetime = datetime.datetime(
-                year=1900, month=1, day=1)
+            today = datetime.datetime.utcnow()
+            from_entered_datetime = today + datetime.timedelta(days=-60)
         if to_entered_datetime is None:
             to_entered_datetime = datetime.datetime.utcnow()
 
         params = {
-            'fromEnteredTime': self._format_datetime(
-                'from_entered_datetime', from_entered_datetime),
-            'toEnteredTime': self._format_datetime(
-                'to_entered_datetime', to_entered_datetime),
+            'fromEnteredTime': self._format_date(
+                'from_entered_datetime', from_entered_datetime.date()),
+            'toEnteredTime': self._format_date(
+                'to_entered_datetime', to_entered_datetime.date()),
         }
 
         if max_results:


### PR DESCRIPTION
While debugging https://tda-api.readthedocs.io/en/stable/client.html#accessing-existing-orders I noticed that when you specify no arguments it would not return any data.  After digging in I saw that https://developer.tdameritrade.com/account-access/apis/get/orders-0 only accepts yyyy-MM-dd format.  Per their documentation I set the "from date" to be 60 days from today.  When testing, it seems like they are lenient around this date.

## Changes

- When passing in no date arguments pass in dates
- Set the from date to be 60 days ago