### PR TITLE
Removed the deprecated get_option_chain parameters `strike_from_date`…

### DIFF
--- a/tda/client/base.py
+++ b/tda/client/base.py
@@ -593,8 +593,6 @@ class BaseClient(EnumEnforcer):
             interval=None,
             strike=None,
             strike_range=None,
-            strike_from_date=None,
-            strike_to_date=None,
             from_date=None,
             to_date=None,
             volatility=None,
@@ -642,24 +640,6 @@ class BaseClient(EnumEnforcer):
         :param option_type: Types of options to return. See
                             :class:`Options.Type` for choices.
         '''
-        if strike_from_date:
-            warnings.warn(
-                'The strike_from_date argument is deprecated and will be ' +
-                'removed in a future version of tda-api. Please use ' +
-                'from_date instead.', Warning)
-            assert from_date is None, \
-                'strike_from_date and from_date cannot be set simultaneously'
-            from_date = strike_from_date
-
-        if strike_to_date:
-            warnings.warn(
-                'The strike_to_date argument is deprecated and will be ' +
-                'removed in a future version of tda-api. Please use ' +
-                'to_date instead.', Warning)
-            assert to_date is None, \
-                'strike_to_date and to_date cannot be set simultaneously'
-            to_date = strike_to_date
-
         contract_type = self.convert_enum(
             contract_type, self.Options.ContractType)
         strategy = self.convert_enum(strategy, self.Options.Strategy)

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -876,22 +876,6 @@ class _TestClient:
                          "from_date, got 'builtins.str'")
 
     
-    def test_get_option_chain_strike_from_date_date(self):
-        self.client.get_option_chain('AAPL', strike_from_date=NOW_DATE)
-        self.mock_session.get.assert_called_once_with(
-            self.make_url('/v1/marketdata/chains'), params={
-                'apikey': API_KEY,
-                'symbol': 'AAPL',
-                'fromDate': NOW_DATE_ISO})
-
-    def test_get_option_chain_strike_from_date_and_from_date(self):
-        with self.assertRaises(AssertionError) as err:
-            self.client.get_option_chain(
-                    'AAPL', strike_from_date=NOW_DATE, from_date=NOW_DATE)
-            self.assertEqual(str(err.exception),
-                    'strike_from_date and from_date cannot be set simultaneously')
-
-
     def test_get_option_chain_to_date_datetime(self):
         self.client.get_option_chain('AAPL', to_date=NOW_DATETIME)
         self.mock_session.get.assert_called_once_with(
@@ -918,23 +902,6 @@ class _TestClient:
                          "to_date, got 'builtins.str'")
 
     
-    def test_get_option_chain_strike_to_date_date(self):
-        self.client.get_option_chain('AAPL', strike_to_date=NOW_DATE)
-        self.mock_session.get.assert_called_once_with(
-            self.make_url('/v1/marketdata/chains'), params={
-                'apikey': API_KEY,
-                'symbol': 'AAPL',
-                'toDate': NOW_DATE_ISO})
-
-
-    def test_get_option_chain_strike_to_date_and_to_date(self):
-        with self.assertRaises(AssertionError) as err:
-            self.client.get_option_chain(
-                    'AAPL', strike_to_date=NOW_DATE, to_date=NOW_DATE)
-            self.assertEqual(str(err.exception),
-                    'strike_to_date and to_date cannot be set simultaneously')
-
-
     def test_get_option_chain_volatility(self):
         self.client.get_option_chain('AAPL', volatility=40.0)
         self.mock_session.get.assert_called_once_with(


### PR DESCRIPTION
… and `strike_to_date`