### PR TITLE
allows disabling enum enforcer on all client methods.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,6 +104,7 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+.idea
 
 # Spyder project settings
 .spyderproject

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -135,8 +135,9 @@ Creating a New Client
 99.9% of users should not create their own clients, and should instead follow 
 the instructions outlined in :ref:`auth`.
 
-For users who want to disable the strict enum type checking on http client, just pass ``enforce_enums=False`` in
-any of the client creation functions described in :ref:`auth`. Just note that for most users, it is advised they
+For users who want to disable the strict enum type checking on http client,
+just pass ``enforce_enums=False`` in any of the client creation functions
+described in :ref:`auth`. Just note that for most users, it is advised they
 stick with the default behavior.
 
 For those brave enough to build their

--- a/docs/client.rst
+++ b/docs/client.rst
@@ -133,7 +133,13 @@ Creating a New Client
 +++++++++++++++++++++
 
 99.9% of users should not create their own clients, and should instead follow 
-the instructions outlined in :ref:`auth`. For those brave enough to build their
+the instructions outlined in :ref:`auth`.
+
+For users who want to disable the strict enum type checking on http client, just pass ``enforce_enums=False`` in
+any of the client creation functions described in :ref:`auth`. Just note that for most users, it is advised they
+stick with the default behavior.
+
+For those brave enough to build their
 own, the constructor looks like this:
 
 .. automethod:: tda.client.Client.__init__

--- a/examples/client_from_access_functions.py
+++ b/examples/client_from_access_functions.py
@@ -1,0 +1,43 @@
+'''
+This example demonstrates how to create a client using the 
+``client_from_access_functions`` method. This is an advanced piece of 
+functionality designed for users who want to customize the reading and writing 
+of their tokens. Most notably, it is useful for users who want to safely store 
+their tokens in a cloud environment where they do not have access to a 
+persistent filesystems, such as on AWS Lambda.
+'''
+
+
+import tda
+
+API_KEY = 'XXXXXX'
+
+
+# For the purposes of this demonstration, we will be storing the token object in 
+# memory. For your use case, replace the contents of these functions with reads 
+# and writes to your backing store.
+
+
+# Note we assume that the token was already created and exists in the backing 
+# store.
+IN_MEMORY_TOKEN = {
+        'dummy': 'token',
+        'please': 'ignore',
+}
+
+def read_token():
+    return IN_MEMORY_TOKEN
+
+# Note the refresh_token kwarg is mandatory. It is passed by authlib on token 
+# refreshes, and contains the refresh token that was used to generate the new 
+# token (i.e. the first parameter). The current best practice is to ignore it, 
+# but it's required.
+def write_token(token, refresh_token=None):
+    global IN_MEMORY_TOKEN
+    IN_MEMORY_TOKEN = token
+
+
+client = tda.auth.client_from_access_functions(
+        API_KEY,
+        token_read_func=read_token,
+        token_write_func=write_token)

--- a/tda/auth.py
+++ b/tda/auth.py
@@ -82,20 +82,25 @@ def client_from_token_file(token_path, api_key, asyncio=False, enforce_enums=Tru
                        :func:`~tda.auth.easy_client` to create one.
     :param api_key: Your TD Ameritrade application's API key, also known as the
                     client ID.
-    :param asyncio: If set to ``True``, this will enable async support allowing the client to be used in an async
-                    environment. Defaults to ``False``
-    :param enforce_enums: Set it to ``False`` to disable the enum checks on ALL the client methods. Only do it if you
-                          know you really need it. For most users, it is advised to use enums to avoid errors.
+    :param asyncio: If set to ``True``, this will enable async support allowing
+                    the client to be used in an async environment. Defaults to
+                    ``False``
+    :param enforce_enums: Set it to ``False`` to disable the enum checks on ALL
+                          the client methods. Only do it if you know you really
+                          need it. For most users, it is advised to use enums
+                          to avoid errors.
     '''
 
     load = __token_loader(token_path)
 
     return client_from_access_functions(
-        api_key, load, __update_token(token_path), asyncio=asyncio, enforce_enums=enforce_enums)
+        api_key, load, __update_token(token_path), asyncio=asyncio,
+        enforce_enums=enforce_enums)
 
 
 def __fetch_and_register_token_from_redirect(
-        oauth, redirected_url, api_key, token_path, token_write_func, asyncio, enforce_enums=True):
+        oauth, redirected_url, api_key, token_path, token_write_func, asyncio,
+        enforce_enums=True):
     token = oauth.fetch_token(
         TOKEN_ENDPOINT,
         authorization_response=redirected_url,
@@ -267,7 +272,8 @@ class TokenMetadata:
 # TODO: Raise an exception when passing both token_path and token_write_func
 def client_from_login_flow(webdriver, api_key, redirect_url, token_path,
                            redirect_wait_time_seconds=0.1, max_waits=3000,
-                           asyncio=False, token_write_func=None, enforce_enums=True):
+                           asyncio=False, token_write_func=None,
+                           enforce_enums=True):
     '''
     Uses the webdriver to perform an OAuth webapp login flow and creates a
     client wrapped around the resulting token. The client will be configured to
@@ -286,10 +292,13 @@ def client_from_login_flow(webdriver, api_key, redirect_url, token_path,
                        file already exists, it will be overwritten with a new
                        one. Updated tokens will be written to this path as well.
 
-    :param asyncio: If set to ``True``, this will enable async support allowing the client to be used in an async
-                    environment. Defaults to ``False``
-    :param enforce_enums: Set it to ``False`` to disable the enum checks on ALL the client methods. Only do it if you
-                          know you really need it. For most users, it is advised to use enums to avoid errors.
+    :param asyncio: If set to ``True``, this will enable async support allowing
+                    the client to be used in an async environment. Defaults to
+                    ``False``
+    :param enforce_enums: Set it to ``False`` to disable the enum checks on ALL
+                          the client methods. Only do it if you know you really
+                          need it. For most users, it is advised to use enums
+                          to avoid errors.
     '''
     get_logger().info('Creating new token with redirect URL \'%s\' ' +
                        'and token path \'%s\'', redirect_url, token_path)
@@ -341,7 +350,8 @@ def client_from_login_flow(webdriver, api_key, redirect_url, token_path,
 
 
 def client_from_manual_flow(api_key, redirect_url, token_path,
-                            asyncio=False, token_write_func=None, enforce_enums=True):
+                            asyncio=False, token_write_func=None,
+                            enforce_enums=True):
     '''
     Walks the user through performing an OAuth login flow by manually
     copy-pasting URLs, and returns a client wrapped around the resulting token.
@@ -360,10 +370,13 @@ def client_from_manual_flow(api_key, redirect_url, token_path,
     :param token_path: Path to which the new token will be written. If the token
                        file already exists, it will be overwritten with a new
                        one. Updated tokens will be written to this path as well.
-    :param asyncio: If set to ``True``, this will enable async support allowing the client to be used in an async
-                    environment. Defaults to ``False``
-    :param enforce_enums: Set it to ``False`` to disable the enum checks on ALL the client methods. Only do it if you
-                          know you really need it. For most users, it is advised to use enums to avoid errors.
+    :param asyncio: If set to ``True``, this will enable async support allowing
+                    the client to be used in an async environment. Defaults to
+                    ``False``
+    :param enforce_enums: Set it to ``False`` to disable the enum checks on ALL
+                          the client methods. Only do it if you know you really
+                          need it. For most users, it is advised to use enums
+                          to avoid errors.
     '''
     get_logger().info('Creating new token with redirect URL \'%s\' ' +
                        'and token path \'%s\'', redirect_url, token_path)
@@ -439,15 +452,19 @@ def easy_client(api_key, redirect_uri, token_path, webdriver_func=None,
     :param webdriver_func: Function that returns a webdriver for use in fetching
                            a new token. Will only be called if the token file
                            cannot be found.
-    :param asyncio: If set to ``True``, this will enable async support allowing the client to be used in an async
-                    environment. Defaults to ``False``
-    :param enforce_enums: Set it to ``False`` to disable the enum checks on ALL the client methods. Only do it if you
-                          know you really need it. For most users, it is advised to use enums to avoid errors.
+    :param asyncio: If set to ``True``, this will enable async support allowing
+                    the client to be used in an async environment. Defaults to
+                    ``False``
+    :param enforce_enums: Set it to ``False`` to disable the enum checks on ALL
+                          the client methods. Only do it if you know you really
+                          need it. For most users, it is advised to use enums
+                          to avoid errors.
     '''
     logger = get_logger()
 
     if os.path.isfile(token_path):
-        c = client_from_token_file(token_path, api_key, asyncio=asyncio, enforce_enums=enforce_enums)
+        c = client_from_token_file(token_path, api_key, asyncio=asyncio,
+                                   enforce_enums=enforce_enums)
         logger.info(
                 'Returning client loaded from token file \'%s\'', token_path)
         return c
@@ -457,7 +474,8 @@ def easy_client(api_key, redirect_uri, token_path, webdriver_func=None,
         if webdriver_func is not None:
             with webdriver_func() as driver:
                 c = client_from_login_flow(
-                    driver, api_key, redirect_uri, token_path, asyncio=asyncio, enforce_enums=enforce_enums)
+                    driver, api_key, redirect_uri, token_path, asyncio=asyncio,
+                    enforce_enums=enforce_enums)
                 logger.info(
                     'Returning client fetched using webdriver, writing' +
                     'token to \'%s\'', token_path)
@@ -468,7 +486,8 @@ def easy_client(api_key, redirect_uri, token_path, webdriver_func=None,
 
 
 def client_from_access_functions(api_key, token_read_func,
-                                 token_write_func, asyncio=False, enforce_enums=True):
+                                 token_write_func, asyncio=False,
+                                 enforce_enums=True):
     '''
     Returns a session from an existing token file, using the accessor methods to
     read and write the token. This is an advanced method for users who do not
@@ -495,10 +514,13 @@ def client_from_access_functions(api_key, token_read_func,
                              called whenever the token is updated, such as when
                              it is refreshed. See the above-mentioned example 
                              for what parameters this method takes.
-    :param asyncio: If set to ``True``, this will enable async support allowing the client to be used in an async
-                    environment. Defaults to ``False``
-    :param enforce_enums: Set it to ``False`` to disable the enum checks on ALL the client methods. Only do it if you
-                          know you really need it. For most users, it is advised to use enums to avoid errors.
+    :param asyncio: If set to ``True``, this will enable async support allowing
+                    the client to be used in an async environment. Defaults to
+                    ``False``
+    :param enforce_enums: Set it to ``False`` to disable the enum checks on ALL
+                          the client methods. Only do it if you know you really
+                          need it. For most users, it is advised to use enums
+                          to avoid errors.
     '''
     token = token_read_func()
 

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -49,7 +49,8 @@ class ClientFromTokenFileTest(unittest.TestCase):
 
         self.assertEqual('returned client',
                          auth.client_from_token_file(self.pickle_path, API_KEY))
-        client.assert_called_once_with(API_KEY, _, token_metadata=_, enforce_enums=_)
+        client.assert_called_once_with(API_KEY, _, token_metadata=_,
+                                       enforce_enums=_)
         sync_session.assert_called_once_with(
             API_KEY,
             token=self.token,
@@ -67,7 +68,8 @@ class ClientFromTokenFileTest(unittest.TestCase):
 
         self.assertEqual('returned client',
                          auth.client_from_token_file(self.json_path, API_KEY))
-        client.assert_called_once_with(API_KEY, _, token_metadata=_, enforce_enums=_)
+        client.assert_called_once_with(API_KEY, _, token_metadata=_,
+                                       enforce_enums=_)
         sync_session.assert_called_once_with(
             API_KEY,
             token=self.token,
@@ -125,8 +127,10 @@ class ClientFromTokenFileTest(unittest.TestCase):
         client.return_value = 'returned client'
 
         self.assertEqual('returned client',
-                         auth.client_from_token_file(self.json_path, API_KEY, enforce_enums=False))
-        client.assert_called_once_with(API_KEY, _, token_metadata=_, enforce_enums=False)
+                         auth.client_from_token_file(self.json_path, API_KEY,
+                                                     enforce_enums=False))
+        client.assert_called_once_with(API_KEY, _, token_metadata=_,
+                                       enforce_enums=False)
         sync_session.assert_called_once_with(
             API_KEY,
             token=self.token,
@@ -144,7 +148,8 @@ class ClientFromTokenFileTest(unittest.TestCase):
 
         self.assertEqual('returned client',
                          auth.client_from_token_file(self.json_path, API_KEY))
-        client.assert_called_once_with(API_KEY, _, token_metadata=_, enforce_enums=True)
+        client.assert_called_once_with(API_KEY, _, token_metadata=_,
+                                       enforce_enums=True)
         sync_session.assert_called_once_with(
             API_KEY,
             token=self.token,
@@ -257,7 +262,8 @@ class ClientFromAccessFunctionsTest(unittest.TestCase):
                              token_read_func,
                              token_write_func, enforce_enums=False))
 
-        client.assert_called_once_with('API_KEY@AMER.OAUTHAP', _, token_metadata=_, enforce_enums=False)
+        client.assert_called_once_with('API_KEY@AMER.OAUTHAP', _, token_metadata=_,
+                                       enforce_enums=False)
 
         sync_session.assert_called_once_with(
             'API_KEY@AMER.OAUTHAP',
@@ -299,7 +305,8 @@ class ClientFromAccessFunctionsTest(unittest.TestCase):
                              token_read_func,
                              token_write_func))
 
-        client.assert_called_once_with('API_KEY@AMER.OAUTHAP', _, token_metadata=_, enforce_enums=True)
+        client.assert_called_once_with('API_KEY@AMER.OAUTHAP', _, token_metadata=_,
+                                       enforce_enums=True)
 
         sync_session.assert_called_once_with(
             'API_KEY@AMER.OAUTHAP',
@@ -569,9 +576,11 @@ class ClientFromLoginFlow(unittest.TestCase):
                          auth.client_from_login_flow(
                              webdriver, API_KEY, REDIRECT_URL,
                              self.json_path,
-                             redirect_wait_time_seconds=0.0, enforce_enums=False))
+                             redirect_wait_time_seconds=0.0,
+                             enforce_enums=False))
 
-        client.assert_called_once_with(API_KEY, _, token_metadata=_, enforce_enums=False)
+        client.assert_called_once_with(API_KEY, _, token_metadata=_,
+                                       enforce_enums=False)
 
         sync_session.assert_called_with(
             _, token=_, auto_refresh_url=_, auto_refresh_kwargs=_,
@@ -607,7 +616,8 @@ class ClientFromLoginFlow(unittest.TestCase):
                              self.json_path,
                              redirect_wait_time_seconds=0.0))
 
-        client.assert_called_once_with(API_KEY, _, token_metadata=_, enforce_enums=True)
+        client.assert_called_once_with(API_KEY, _, token_metadata=_,
+                                       enforce_enums=True)
 
         sync_session.assert_called_with(
             _, token=_, auto_refresh_url=_, auto_refresh_kwargs=_,
@@ -772,9 +782,11 @@ class ClientFromManualFlow(unittest.TestCase):
 
         self.assertEqual('returned client',
                          auth.client_from_manual_flow(
-                             API_KEY, REDIRECT_URL, self.json_path, enforce_enums=False))
+                             API_KEY, REDIRECT_URL, self.json_path,
+                             enforce_enums=False))
 
-        client.assert_called_once_with(API_KEY, _, token_metadata=_, enforce_enums=False)
+        client.assert_called_once_with(API_KEY, _, token_metadata=_,
+                                       enforce_enums=False)
 
         with open(self.json_path, 'r') as f:
             self.assertEqual({
@@ -803,7 +815,8 @@ class ClientFromManualFlow(unittest.TestCase):
                          auth.client_from_manual_flow(
                              API_KEY, REDIRECT_URL, self.json_path))
 
-        client.assert_called_once_with(API_KEY, _, token_metadata=_, enforce_enums=True)
+        client.assert_called_once_with(API_KEY, _, token_metadata=_,
+                                       enforce_enums=True)
 
         with open(self.json_path, 'r') as f:
             self.assertEqual({
@@ -880,8 +893,10 @@ class EasyClientTest(unittest.TestCase):
                               webdriver_func=webdriver_func, enforce_enums=False))
 
         webdriver_func.assert_called_once()
-        client_from_login_flow.assert_called_once_with(_, API_KEY, REDIRECT_URL, self.json_path,
-                                                       asyncio=False, enforce_enums=False)
+        client_from_login_flow.assert_called_once_with(_, API_KEY, REDIRECT_URL,
+                                                       self.json_path,
+                                                       asyncio=False,
+                                                       enforce_enums=False)
 
     @no_duplicates
     @patch('tda.auth.client_from_login_flow')
@@ -900,8 +915,10 @@ class EasyClientTest(unittest.TestCase):
                               webdriver_func=webdriver_func))
 
         webdriver_func.assert_called_once()
-        client_from_login_flow.assert_called_once_with(_, API_KEY, REDIRECT_URL, self.json_path,
-                                                       asyncio=False, enforce_enums=True)
+        client_from_login_flow.assert_called_once_with(_, API_KEY, REDIRECT_URL,
+                                                       self.json_path,
+                                                       asyncio=False,
+                                                       enforce_enums=True)
 
     @no_duplicates
     @patch('tda.auth.client_from_token_file')
@@ -912,8 +929,11 @@ class EasyClientTest(unittest.TestCase):
         client_from_token_file.return_value = self.token
 
         self.assertEquals(self.token,
-                          auth.easy_client(API_KEY, REDIRECT_URL, self.json_path, enforce_enums=False))
-        client_from_token_file.assert_called_once_with(self.json_path, API_KEY, asyncio=False, enforce_enums=False)
+                          auth.easy_client(API_KEY, REDIRECT_URL, self.json_path,
+                                           enforce_enums=False))
+        client_from_token_file.assert_called_once_with(self.json_path, API_KEY,
+                                                       asyncio=False,
+                                                       enforce_enums=False)
 
     @no_duplicates
     @patch('tda.auth.client_from_token_file')
@@ -925,7 +945,9 @@ class EasyClientTest(unittest.TestCase):
 
         self.assertEquals(self.token,
                           auth.easy_client(API_KEY, REDIRECT_URL, self.json_path))
-        client_from_token_file.assert_called_once_with(self.json_path, API_KEY, asyncio=False, enforce_enums=True)
+        client_from_token_file.assert_called_once_with(self.json_path, API_KEY,
+                                                       asyncio=False,
+                                                       enforce_enums=True)
 
 
 class TokenMetadataTest(unittest.TestCase):

--- a/tests/auth_test.py
+++ b/tests/auth_test.py
@@ -131,11 +131,6 @@ class ClientFromTokenFileTest(unittest.TestCase):
                                                      enforce_enums=False))
         client.assert_called_once_with(API_KEY, _, token_metadata=_,
                                        enforce_enums=False)
-        sync_session.assert_called_once_with(
-            API_KEY,
-            token=self.token,
-            token_endpoint=_,
-            update_token=_)
 
     @no_duplicates
     @patch('tda.auth.Client')
@@ -150,11 +145,6 @@ class ClientFromTokenFileTest(unittest.TestCase):
                          auth.client_from_token_file(self.json_path, API_KEY))
         client.assert_called_once_with(API_KEY, _, token_metadata=_,
                                        enforce_enums=True)
-        sync_session.assert_called_once_with(
-            API_KEY,
-            token=self.token,
-            token_endpoint=_,
-            update_token=_)
 
 
 class ClientFromAccessFunctionsTest(unittest.TestCase):
@@ -265,23 +255,6 @@ class ClientFromAccessFunctionsTest(unittest.TestCase):
         client.assert_called_once_with('API_KEY@AMER.OAUTHAP', _, token_metadata=_,
                                        enforce_enums=False)
 
-        sync_session.assert_called_once_with(
-            'API_KEY@AMER.OAUTHAP',
-            token=token,
-            token_endpoint=_,
-            update_token=_)
-        token_read_func.assert_called_once()
-
-        # Verify that the write function is called when the updater is called
-        session_call = sync_session.mock_calls[0]
-        update_token = session_call[2]['update_token']
-
-        update_token(token)
-        self.assertEqual([{
-            'creation_timestamp': None,
-            'token': token,
-        }], token_writes)
-
     @no_duplicates
     @patch('tda.auth.Client')
     @patch('tda.auth.OAuth2Client', new_callable=MockOAuthClient)
@@ -307,23 +280,6 @@ class ClientFromAccessFunctionsTest(unittest.TestCase):
 
         client.assert_called_once_with('API_KEY@AMER.OAUTHAP', _, token_metadata=_,
                                        enforce_enums=True)
-
-        sync_session.assert_called_once_with(
-            'API_KEY@AMER.OAUTHAP',
-            token=token,
-            token_endpoint=_,
-            update_token=_)
-        token_read_func.assert_called_once()
-
-        # Verify that the write function is called when the updater is called
-        session_call = sync_session.mock_calls[0]
-        update_token = session_call[2]['update_token']
-
-        update_token(token)
-        self.assertEqual([{
-            'creation_timestamp': None,
-            'token': token,
-        }], token_writes)
 
 
 REDIRECT_URL = 'https://redirect.url.com'
@@ -582,16 +538,6 @@ class ClientFromLoginFlow(unittest.TestCase):
         client.assert_called_once_with(API_KEY, _, token_metadata=_,
                                        enforce_enums=False)
 
-        sync_session.assert_called_with(
-            _, token=_, auto_refresh_url=_, auto_refresh_kwargs=_,
-            update_token=_)
-
-        with open(self.json_path, 'r') as f:
-            self.assertEqual({
-                'creation_timestamp': MOCK_NOW,
-                'token': self.token
-            }, json.load(f))
-
     @no_duplicates
     @patch('tda.auth.Client')
     @patch('tda.auth.OAuth2Client', new_callable=MockOAuthClient)
@@ -618,16 +564,6 @@ class ClientFromLoginFlow(unittest.TestCase):
 
         client.assert_called_once_with(API_KEY, _, token_metadata=_,
                                        enforce_enums=True)
-
-        sync_session.assert_called_with(
-            _, token=_, auto_refresh_url=_, auto_refresh_kwargs=_,
-            update_token=_)
-
-        with open(self.json_path, 'r') as f:
-            self.assertEqual({
-                'creation_timestamp': MOCK_NOW,
-                'token': self.token
-            }, json.load(f))
 
 
 class ClientFromManualFlow(unittest.TestCase):
@@ -788,12 +724,6 @@ class ClientFromManualFlow(unittest.TestCase):
         client.assert_called_once_with(API_KEY, _, token_metadata=_,
                                        enforce_enums=False)
 
-        with open(self.json_path, 'r') as f:
-            self.assertEqual({
-                'creation_timestamp': MOCK_NOW,
-                'token': self.token,
-            }, json.load(f))
-
     @no_duplicates
     @patch('tda.auth.Client')
     @patch('tda.auth.OAuth2Client', new_callable=MockOAuthClient)
@@ -817,12 +747,6 @@ class ClientFromManualFlow(unittest.TestCase):
 
         client.assert_called_once_with(API_KEY, _, token_metadata=_,
                                        enforce_enums=True)
-
-        with open(self.json_path, 'r') as f:
-            self.assertEqual({
-                'creation_timestamp': MOCK_NOW,
-                'token': self.token,
-            }, json.load(f))
 
 
 class EasyClientTest(unittest.TestCase):


### PR DESCRIPTION
Includes modifications to existing test cases and docs reflecting the changes.

additional test cases added for verifying that the underlying client objects do receive `enforce_enums` flag.