### PR TITLE
Accepting verbose version of contract type ('CALL' and 'PUT)

### DIFF
--- a/tda/orders/options.py
+++ b/tda/orders/options.py
@@ -43,7 +43,7 @@ class OptionSymbol:
                             ``datetime.datetime``, or strings with the
                             format ``[Two digit month][Two digit day][Two
                             digit year]``.
-    :param contract_type: ``P`` for put or ``C`` for call.
+    :param contract_type: ``P` or `PUT`` for put and ``C` or `CALL`` for call.
     :param strike_price_as_string: Strike price, represented by a string as
                                    you would see at the end of a real option
                                    symbol.
@@ -53,9 +53,13 @@ class OptionSymbol:
                  strike_price_as_string):
         self.underlying_symbol = underlying_symbol
 
-        if contract_type not in ('C', 'P'):
-            raise ValueError('Contract type must be one of \'C\' or \'P\'')
-        self.contract_type = contract_type
+        if contract_type in ('C', 'CALL'):
+            self.contract_type = 'C'
+        elif contract_type in ('P', 'PUT'):
+            self.contract_type = 'P'
+        else:
+            raise ValueError(
+                'Contract type must be one of \'C\', \'CALL\', \'P\' or \'PUT\'')
 
         if isinstance(expiration_date, str):
             self.expiration_date = _parse_expiration_date(expiration_date)

--- a/tests/orders/options_test.py
+++ b/tests/orders/options_test.py
@@ -79,12 +79,36 @@ class OptionSymbolTest(unittest.TestCase):
         self.assertEqual('GOOG_121520C2200', op.build())
 
     @no_duplicates
+    def test_init_success_call_verbose_contract_type(self):
+        op = OptionSymbol('GOOG', '121520', 'CALL', '2200')
+        self.assertEqual(op.underlying_symbol, 'GOOG')
+        self.assertEqual(
+            op.expiration_date, datetime.date(
+                year=2020, month=12, day=15))
+        self.assertEqual(op.contract_type, 'C')
+        self.assertEqual(op.strike_price, '2200')
+
+        self.assertEqual('GOOG_121520C2200', op.build())
+
+    @no_duplicates
     def test_init_success_put(self):
         op = OptionSymbol('GOOG', '121520', 'P', '2200')
         self.assertEqual(op.underlying_symbol, 'GOOG')
         self.assertEqual(
                 op.expiration_date, datetime.date(
                     year=2020, month=12, day=15))
+        self.assertEqual(op.contract_type, 'P')
+        self.assertEqual(op.strike_price, '2200')
+
+        self.assertEqual('GOOG_121520P2200', op.build())
+
+    @no_duplicates
+    def test_init_success_put_verbose_contract_type(self):
+        op = OptionSymbol('GOOG', '121520', 'PUT', '2200')
+        self.assertEqual(op.underlying_symbol, 'GOOG')
+        self.assertEqual(
+            op.expiration_date, datetime.date(
+                year=2020, month=12, day=15))
         self.assertEqual(op.contract_type, 'P')
         self.assertEqual(op.strike_price, '2200')
 


### PR DESCRIPTION
Accepting verbose version of contract type ('CALL' and 'PUT) while building OptionSymbol.