### PR TITLE
Issue with decimal strikes in OptionSymbol

### DIFF
--- a/tda/orders/options.py
+++ b/tda/orders/options.py
@@ -90,13 +90,20 @@ class OptionSymbol:
                 'float')
 
         # Remove extraneous zeroes at the end
-        strike_copy = strike_price_as_string
-        while strike_copy[-1] == '0':
-            strike_copy = strike_copy[:-1]
-        if strike_copy[-1] == '.':
-            strike_price_as_string = strike_copy[:-1]
+        cleaned_strike_price = None
+        try:
+            _ = strike_price_as_string.index('.') # check if strike price contains decimal
+            strike_copy = strike_price_as_string
+            while strike_copy[-1] == '0':
+                strike_copy = strike_copy[:-1]
+            if strike_copy[-1] == '.': # if strike price was of the form x.00 then remove the decimal point
+                strike_copy = strike_copy[:-1]
+            cleaned_strike_price = strike_copy
+        except ValueError:
+            cleaned_strike_price = strike_price_as_string
+        
 
-        self.strike_price = strike_price_as_string
+        self.strike_price = cleaned_strike_price
 
     @classmethod
     def parse_symbol(cls, symbol):

--- a/tests/orders/options_test.py
+++ b/tests/orders/options_test.py
@@ -153,6 +153,18 @@ class OptionSymbolTest(unittest.TestCase):
         self.assertEqual(op.strike_price, '2200.25')
 
         self.assertEqual('GOOG_121520P2200.25', op.build())
+    
+    @no_duplicates
+    def test_init_success_decimal_in_strike_with_trailing_zero(self):
+        op = OptionSymbol('GOOG', '121520', 'P', '2200.10')
+        self.assertEqual(op.underlying_symbol, 'GOOG')
+        self.assertEqual(
+                op.expiration_date, datetime.date(
+                    year=2020, month=12, day=15))
+        self.assertEqual(op.contract_type, 'P')
+        self.assertEqual(op.strike_price, '2200.1')
+
+        self.assertEqual('GOOG_121520P2200.1', op.build())
 
     @no_duplicates
     def test_init_success_point_zero_in_strike(self):


### PR DESCRIPTION
When using the api to place options trade I noticed that strike prices following the form x.x0 would not be sanitized to x.x. This caused the symbol to not be found and hence not place the order.

In this change I fixed the sanitation for the strike price to handle such cases and added a test case for this case.